### PR TITLE
Manage CMS content in a `content` state

### DIFF
--- a/src/common/context/Content.context.tsx
+++ b/src/common/context/Content.context.tsx
@@ -1,0 +1,60 @@
+import { createContext, useCallback, useContext, useState } from 'react'
+
+type ContentProviderPops = {
+  children: React.ReactNode
+}
+
+type ContentContextValue = {
+  content: Content
+  initializeContent: ContentSetterFn
+}
+
+class HomeContent {
+  constructor(public fullName: string = '', public greeting: string = '') {}
+}
+
+class AboutContent {
+  constructor(public title: string = '') {}
+}
+
+export interface Content {
+  home: HomeContent
+  about: AboutContent
+}
+
+type ContentSetterFn = (data: Content) => void
+
+const initialContent = {
+  home: new HomeContent(),
+  about: new AboutContent(),
+}
+
+const initialContentContextValue = {
+  content: initialContent,
+  initializeContent: () => null,
+}
+
+export const ContentContext = createContext<ContentContextValue>(
+  initialContentContextValue
+)
+
+export const useContentContext = () => useContext(ContentContext)
+
+export const ContentProvider = ({
+  children,
+}: ContentProviderPops): JSX.Element => {
+  const [content, setContent] = useState<Content>(initialContent)
+
+  const initializeContent: ContentSetterFn = useCallback((data: Content) => {
+    setContent(data)
+  }, [])
+
+  const value = {
+    content,
+    initializeContent,
+  }
+
+  return (
+    <ContentContext.Provider value={value}>{children}</ContentContext.Provider>
+  )
+}

--- a/src/common/context/index.ts
+++ b/src/common/context/index.ts
@@ -1,0 +1,1 @@
+export * from './Content.context'

--- a/src/common/tests/index.ts
+++ b/src/common/tests/index.ts
@@ -1,1 +1,2 @@
+export * from './mocks'
 export * from './setup'

--- a/src/common/tests/mocks.ts
+++ b/src/common/tests/mocks.ts
@@ -1,0 +1,6 @@
+export const mockedContent = {
+  home: {
+    fullName: 'Elloani Ross Pitogo',
+    greeting: 'Hi there',
+  },
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,11 +1,15 @@
 import type { AppProps } from 'next/app'
+
+import { ContentProvider } from '../common/context'
 import { GlobalStyles, Theme } from '../common/styles'
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
-    <Theme>
-      <GlobalStyles />
-      <Component {...pageProps} />
-    </Theme>
+    <ContentProvider>
+      <Theme>
+        <GlobalStyles />
+        <Component {...pageProps} />
+      </Theme>
+    </ContentProvider>
   )
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,8 +1,33 @@
 import Head from 'next/head'
+import { useEffect } from 'react'
+
+import { Content, useContentContext } from '../common/context'
 import { Footer, Header, HeaderProvider } from '../layout'
 import { Home } from '../sections'
 
-export default function Index() {
+export async function getStaticProps() {
+  const { attributes: homeContent } = await require('../../content/home.md')
+
+  return {
+    props: {
+      content: {
+        home: homeContent,
+      },
+    },
+  }
+}
+
+interface IndexProps {
+  content: Content
+}
+
+export default function Index({ content }: IndexProps) {
+  const { initializeContent } = useContentContext()
+
+  useEffect(() => {
+    initializeContent(content)
+  }, [content, initializeContent])
+
   return (
     <>
       <Head>

--- a/src/sections/Home/Home.test.tsx
+++ b/src/sections/Home/Home.test.tsx
@@ -1,5 +1,11 @@
-import { render, screen } from '../../common/tests'
+import { mockedContent, render, screen } from '../../common/tests'
 import { Home } from './Home'
+
+jest.mock('../../common/context', () => ({
+  useContentContext: () => ({
+    content: mockedContent,
+  }),
+}))
 
 const setup = () => {
   render(<Home />)
@@ -7,14 +13,25 @@ const setup = () => {
 
 describe('Home section', () => {
   describe('Layout', () => {
-    it('displays a self-introduction text displayed as header text', () => {
+    it('displays a greeting text', () => {
       setup()
 
-      expect(
-        screen.getByRole('heading', {
-          level: 1,
-        })
-      ).toBeInTheDocument()
+      const greetingText = screen.getByText(
+        new RegExp(mockedContent.home.greeting)
+      )
+
+      expect(greetingText).toBeInTheDocument()
+    })
+
+    it('displays my full name as header text', () => {
+      setup()
+
+      const fullNameText = screen.getByRole('heading', {
+        name: new RegExp(mockedContent.home.fullName),
+        level: 1,
+      })
+
+      expect(fullNameText).toBeInTheDocument()
     })
 
     it('displays more details about me displayed in short sentences', () => {

--- a/src/sections/Home/Home.tsx
+++ b/src/sections/Home/Home.tsx
@@ -2,15 +2,8 @@ import styled from 'styled-components'
 import { Button, ButtonVariant } from '../../common/components'
 import { SocialIcons } from '../../common/components/SocialIcons'
 import { SOCIAL_LINKS } from '../../common/constants'
+import { useContentContext } from '../../common/context'
 import { container, highlightText } from '../../common/styles/utilities'
-import { attributes } from '../../../content/home.md'
-
-interface HomeContentAttributes {
-  fullName: string
-  greeting: string
-}
-
-const { fullName, greeting } = attributes as unknown as HomeContentAttributes
 
 const S = {
   Home: styled.section`
@@ -70,46 +63,52 @@ const S = {
   `,
 }
 
-export const Home = () => (
-  <S.Home>
-    <S.HomeContainer>
-      <S.HomeTitle>
-        <S.HomeTitleSecondary>{greeting} I am</S.HomeTitleSecondary>
-        <S.HomeTitlePrimary>{fullName}</S.HomeTitlePrimary>
-      </S.HomeTitle>
-      <S.HomeSubtitle data-testid="home-subtitle">
-        <S.HomeSubtitleText>
-          You can call me{' '}
-          <S.HomeSubtitleTextHighlighy>Wani</S.HomeSubtitleTextHighlighy>.
-        </S.HomeSubtitleText>
-        <S.HomeSubtitleText>
-          School-taught{' '}
-          <S.HomeSubtitleTextHighlighy>
-            Computer Engineer
-          </S.HomeSubtitleTextHighlighy>
-          ,
-        </S.HomeSubtitleText>
-        <S.HomeSubtitleText>
-          Industry-taught{' '}
-          <S.HomeSubtitleTextHighlighy>
-            Front-end Web Developer
-          </S.HomeSubtitleTextHighlighy>
-          .
-        </S.HomeSubtitleText>
-      </S.HomeSubtitle>
-      <S.HomeCTAButtonGroup>
-        <S.HomeCTAButton asLink href="#projects">
-          View my work
-        </S.HomeCTAButton>
-        <S.HomeCTAButton
-          asLink
-          href="#contact"
-          variant={ButtonVariant.OUTLINED}
-        >
-          Contact me
-        </S.HomeCTAButton>
-      </S.HomeCTAButtonGroup>
-      <SocialIcons icons={Object.values(SOCIAL_LINKS)} />
-    </S.HomeContainer>
-  </S.Home>
-)
+export const Home = () => {
+  const { content } = useContentContext()
+
+  const { fullName, greeting } = content?.home
+
+  return (
+    <S.Home>
+      <S.HomeContainer>
+        <S.HomeTitle>
+          <S.HomeTitleSecondary>{greeting} I am</S.HomeTitleSecondary>
+          <S.HomeTitlePrimary>{fullName}</S.HomeTitlePrimary>
+        </S.HomeTitle>
+        <S.HomeSubtitle data-testid="home-subtitle">
+          <S.HomeSubtitleText>
+            You can call me{' '}
+            <S.HomeSubtitleTextHighlighy>Wani</S.HomeSubtitleTextHighlighy>.
+          </S.HomeSubtitleText>
+          <S.HomeSubtitleText>
+            School-taught{' '}
+            <S.HomeSubtitleTextHighlighy>
+              Computer Engineer
+            </S.HomeSubtitleTextHighlighy>
+            ,
+          </S.HomeSubtitleText>
+          <S.HomeSubtitleText>
+            Industry-taught{' '}
+            <S.HomeSubtitleTextHighlighy>
+              Front-end Web Developer
+            </S.HomeSubtitleTextHighlighy>
+            .
+          </S.HomeSubtitleText>
+        </S.HomeSubtitle>
+        <S.HomeCTAButtonGroup>
+          <S.HomeCTAButton asLink href="#projects">
+            View my work
+          </S.HomeCTAButton>
+          <S.HomeCTAButton
+            asLink
+            href="#contact"
+            variant={ButtonVariant.OUTLINED}
+          >
+            Contact me
+          </S.HomeCTAButton>
+        </S.HomeCTAButtonGroup>
+        <SocialIcons icons={Object.values(SOCIAL_LINKS)} />
+      </S.HomeContainer>
+    </S.Home>
+  )
+}


### PR DESCRIPTION
Load the contents from the md files in pages/index's getStaticProps. On mount, initialize content state with this. This will make testing dynamic content easily in the sections instead of importing md file into the sections since there's an issue with md files in the testing environment